### PR TITLE
docs: fix panvimdoc command syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,23 +9,23 @@ This is particularly useful for editing embedded code blocks (e.g., JavaScript o
 - Changes are automatically synchronized to the original buffer when you save (`:w`) the temporary buffer.
 - Integration with `context_filetype.vim` to automatically detect the filetype based on the cursor position.
 
-## Usage
+## USAGE
 
-### Commands
+### COMMANDS
 
-#### `:[range]PartEdit {filetype}`
+:[range]PartEdit {filetype} {:PartEdit}
 
-Opens the specified `[range]` in a new buffer with the given `{filetype}`.
+: Opens the specified `[range]` in a new buffer with the given `{filetype}`.
 If `{filetype}` is omitted, the current buffer's filetype is used.
 
-#### `:PartEditContext`
+:PartEditContext {:PartEditContext}
 
-Automatically detects the context at the current cursor position (e.g., an embedded code block) and opens that range in a temporary buffer with the appropriate filetype.
+: Automatically detects the context at the current cursor position (e.g., an embedded code block) and opens that range in a temporary buffer with the appropriate filetype.
 
 > [!NOTE]
 > This command requires [Shougo/context_filetype.vim](https://github.com/Shougo/context_filetype.vim).
 
-### Mappings
+### MAPPINGS
 
 No default mappings are provided. You can configure your own using the following `<Plug>` mappings:
 


### PR DESCRIPTION
This PR fixes the issue where command help tags were not correctly generated by `panvimdoc` due to incorrect syntax in `README.md`.

### Changes
- Restructured headers (`## Usage` -> `## USAGE`, `### Commands` -> `### COMMANDS`) to match `panvimdoc` expectations.
- Removed backticks from command definitions and added explicit tags: `{:PartEdit}` and `{:PartEditContext}`.
- Converted command descriptions to definition list format (using `: ` prefix) for proper right-alignment in the generated vimhelp file.
- Removed unnecessary indentation from multi-line descriptions.